### PR TITLE
[Feat/#21] - fix 구글 STT 키 인식 안되는 문제 리소스 로더 따로 생성해서 불러오게 수정

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -21,6 +21,13 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Make GitHub Secrets files
+        run: |
+          cat <<EOF > ./src/main/resources/google-stt-key.json
+          ${{ secrets.GOOGLE_STT_KEY }}
+          EOF
+        shell: bash
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
 
@@ -64,8 +71,7 @@ jobs:
       - name: Make Zip File
         run: |
           echo "${{ secrets.ENV_PROD }}" > .env.prod
-          printf '%s' "${{ secrets.GOOGLE_STT_KEY }}" > google-stt-key.json
-          zip -r ./olllim-deploy.zip appspec.yml docker-compose.yml .env.prod run.sh google-stt-key.json
+          zip -r ./olllim-deploy.zip appspec.yml docker-compose.yml .env.prod run.sh
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@ out/
 .env.prod
 dump.rdb
 
-google-stt-key.json
+src/main/resources/google-stt-key.json

--- a/src/main/java/haennihaesseo/sandoll/global/infra/stt/GoogleSttClient.java
+++ b/src/main/java/haennihaesseo/sandoll/global/infra/stt/GoogleSttClient.java
@@ -5,9 +5,8 @@ import com.google.cloud.speech.v1.*;
 import com.google.protobuf.ByteString;
 import haennihaesseo.sandoll.global.exception.GlobalException;
 import haennihaesseo.sandoll.global.status.ErrorStatus;
+import haennihaesseo.sandoll.global.util.ResourceLoader;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -25,9 +24,10 @@ public class GoogleSttClient {
 
     private final SpeechSettings speechSettings;
 
-    public GoogleSttClient(@Value("${spring.cloud.gcp.credentials.location}") Resource credentialsResource) {
+    public GoogleSttClient() {
         try {
-            GoogleCredentials credentials = GoogleCredentials.fromStream(credentialsResource.getInputStream());
+            GoogleCredentials credentials = GoogleCredentials.fromStream(
+                    ResourceLoader.getResourceAsStream("google-stt-key.json"));
             this.speechSettings = SpeechSettings.newBuilder()
                     .setCredentialsProvider(() -> credentials)
                     .build();

--- a/src/main/java/haennihaesseo/sandoll/global/util/ResourceLoader.java
+++ b/src/main/java/haennihaesseo/sandoll/global/util/ResourceLoader.java
@@ -1,0 +1,32 @@
+package haennihaesseo.sandoll.global.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import haennihaesseo.sandoll.global.exception.GlobalException;
+import haennihaesseo.sandoll.global.status.ErrorStatus;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import org.springframework.core.io.ClassPathResource;
+
+public class ResourceLoader {
+
+  private final static ObjectMapper objectMapper = new ObjectMapper();
+
+  public static String getResourceContent(String resourceName) {
+    try {
+      var resource = new ClassPathResource(resourceName);
+      return new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      throw new GlobalException(ErrorStatus.NOT_FOUND);
+    }
+  }
+
+  public static InputStream getResourceAsStream(String resourceName) {
+    try {
+      return new ClassPathResource(resourceName).getInputStream();
+    } catch (Exception e) {
+      throw new GlobalException(ErrorStatus.NOT_FOUND);
+    }
+  }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -52,11 +52,10 @@ spring.security.oauth2.client.provider.kakao.user-name-attribute=id
 app.server-url=${SERVER_URL}
 app.discord-webhook-url=${DISCORD_WEBHOOK_URL}
 
-#????
+#discord
 app.discord-alarm-enabled=${DISCORD_ALARM_ENABLED:false}
 
-#??STT
-spring.cloud.gcp.credentials.location=file:./google-stt-key.json
+#file upload
 spring.servlet.multipart.max-file-size=20MB
 spring.servlet.multipart.max-request-size=20MB
 


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #

### 💡 작업내용
- 현재 배포 실패한 이유가 google-stt-key.json 파일 경로 인식을 못하는 문제인 것 같아서 이를 해결하기 위해서 ResourceLoader를 만들어서 직접 불러오게 하도록 수정하였습니다.

### 📸 스크린샷(선택)

### 📝 기타
해당 ResourceLoader는 추후 프롬프트 내용 불러오기 등에서 활용 가능합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**파일 업로드**
- 최대 파일 업로드 크기와 요청 크기를 20MB로 설정했습니다.

**개선사항**
- 음성 인식 기능의 설정이 개선되었습니다.
- 배포 프로세스가 최적화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->