### PR TITLE
[Refactor/#61]: 템플릿 목록 조회 API 구현 및 응답 형식 변경

### DIFF
--- a/src/main/java/haennihaesseo/sandoll/domain/deco/converter/DecoConverter.java
+++ b/src/main/java/haennihaesseo/sandoll/domain/deco/converter/DecoConverter.java
@@ -25,6 +25,27 @@ public class DecoConverter {
                 .build();
     }
 
+    public TemplatesResponse toTemplatesResponse(List<Template> templates, List<String> order) {
+        // 이름 -> Template 매핑
+        java.util.Map<String, Template> templateMap = templates.stream()
+                .collect(java.util.stream.Collectors.toMap(Template::getName, t -> t));
+
+        // 순서에 맞게 정렬
+        List<TemplatesResponse.TemplateDto> temps = order.stream()
+                .filter(templateMap::containsKey)
+                .map(templateMap::get)
+                .map(t -> TemplatesResponse.TemplateDto.builder()
+                        .templateId(t.getTemplateId())
+                        .name(t.getName())
+                        .previewImageUrl(t.getPreviewImageUrl())
+                        .build())
+                .toList();
+
+        return TemplatesResponse.builder()
+                .templates(temps)
+                .build();
+    }
+
     public List<BgmsResponse.BgmDto> toBgmDto(List<Bgm> bgms) {
         return bgms.stream()
                 .map(b -> BgmsResponse.BgmDto.builder()

--- a/src/main/java/haennihaesseo/sandoll/domain/deco/repository/TemplateRepository.java
+++ b/src/main/java/haennihaesseo/sandoll/domain/deco/repository/TemplateRepository.java
@@ -2,6 +2,7 @@ package haennihaesseo.sandoll.domain.deco.repository;
 
 import haennihaesseo.sandoll.domain.deco.entity.Template;
 import haennihaesseo.sandoll.domain.deco.entity.enums.Size;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface TemplateRepository extends JpaRepository<Template, Long> {
 
     Template findByNameAndSize(String name, Size size);
+
+    List<Template> findByNameInAndSize(List<String> names, Size size);
 }

--- a/src/main/java/haennihaesseo/sandoll/domain/deco/service/TemplateService.java
+++ b/src/main/java/haennihaesseo/sandoll/domain/deco/service/TemplateService.java
@@ -15,7 +15,6 @@ import haennihaesseo.sandoll.domain.letter.status.LetterErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -27,14 +26,22 @@ public class TemplateService {
     private final TemplateRepository templateRepository;
     private final DecoConverter decoConverter;
     private final CachedLetterRepository cachedLetterRepository;
+    private final List<String> TEMPLATE_ORDER = List.of(
+            "무지",
+            "줄글",
+            "모눈",
+            "설날",
+            "생일A",
+            "생일B"
+    );
 
     /**
-     * DB의 전체 템플릿 조회
+     * 템플릿 목록 조회 (이름별 SMALL 사이즈 하나씩)
      * @return templates(templateId, name, previewImageUrl)
      */
     public TemplatesResponse getAllTemplates() {
-        List<Template> templates = templateRepository.findAll();
-        return decoConverter.toTemplatesResponse(templates);
+        List<Template> templates = templateRepository.findByNameInAndSize(TEMPLATE_ORDER, Size.SMALL);
+        return decoConverter.toTemplatesResponse(templates, TEMPLATE_ORDER);
     }
 
     /**

--- a/src/main/java/haennihaesseo/sandoll/domain/font/service/FontService.java
+++ b/src/main/java/haennihaesseo/sandoll/domain/font/service/FontService.java
@@ -1,7 +1,9 @@
 package haennihaesseo.sandoll.domain.font.service;
 
 
+import haennihaesseo.sandoll.domain.deco.entity.Template;
 import haennihaesseo.sandoll.domain.deco.entity.enums.Size;
+import haennihaesseo.sandoll.domain.deco.repository.TemplateRepository;
 import haennihaesseo.sandoll.domain.font.dto.response.ContextFontResponse;
 import haennihaesseo.sandoll.domain.font.dto.response.RecommendFontResponse;
 import haennihaesseo.sandoll.domain.font.dto.response.RefreshFontResponse;
@@ -36,6 +38,7 @@ public class FontService {
   private final FontRepository fontRepository;
   private final FontConverter fontConverter;
   private final int SELECT_COUNT = 3; // 한 번에 추천할 폰트 개수
+  private final TemplateRepository templateRepository;
 
   /**
    * 폰트 적용
@@ -55,7 +58,7 @@ public class FontService {
     // 폰트 적용
     cachedLetter.setFont(font.getFontId(), font.getFontUrl());
 
-    // 글자수 세기 -> 전체 글자수 + \n은 10자로 간주 (바뀔 수 있음)
+    // 글자수 세기 -> 전체 글자수 + \n은 20자로 간주 (바뀔 수 있음)
     int charCount = 0;
     String content = cachedLetter.getContent();
     for (char c : content.toCharArray()) {
@@ -68,9 +71,9 @@ public class FontService {
 
     Size size = Size.fromLength(charCount);
     //TODO:추후 템플릿 저장 후 주석 풀기, 현재는 디폴트 무지 템플릿으로 설정
-//    Template setTemplate = templateRepository.findByNameAndSize("무지", size); // Default인 무지로 설정
-    cachedLetter.setTemplateId(1L);
-    cachedLetter.setTemplateUrl("https://sandoll-s3-bucket.s3.ap-northeast-2.amazonaws.com/template/%E1%84%86%E1%85%AE%E1%84%8C%E1%85%B5.png");
+    Template setTemplate = templateRepository.findByNameAndSize("무지", size); // Default인 무지로 설정
+    cachedLetter.setTemplateId(setTemplate.getTemplateId());
+    cachedLetter.setTemplateUrl(setTemplate.getImageUrl());
     cachedLetterRepository.save(cachedLetter);
   }
 


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #61 

### 💡 작업내용
- 템플릿 데이터 S3에 업로드 완료해서 조회 시 프리뷰 이미지가 나오도록 수정하였습니다.
- 편지지 순서를 백에 저장하여 프론트에 순서에 맞춰서 주도록 코드 적용하였습니다.
- 최초 편지 생성 시 무지 S 사이즈 적용되도록 하였습니다.

### 📸 스크린샷(선택)

### 📝 기타
- 로컬에 데이터가 없어서 추후 테스트 필요합니다.

(참고사항, 리뷰어에게 전하고 싶은 말 등을 넣어주세요)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능 및 개선사항

* **새로운 기능**
  * 템플릿 조회 시 정의된 순서대로 필터링 및 정렬
  * 크기별 템플릿 배치 조회 기능 추가

* **개선사항**
  * 글씨 적용 시 템플릿 동적 조회로 안정성 개선
  * 줄바꿈당 글자 수 해석값 증대 (10 → 20)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->