### PR TITLE
[Refactor/#66] :  OAuth 로그인 후 프론트 리다이렉트 경로 지정 기능 추가

### DIFF
--- a/src/main/java/haennihaesseo/sandoll/global/auth/handler/CustomOAuth2AuthorizationRequestResolver.java
+++ b/src/main/java/haennihaesseo/sandoll/global/auth/handler/CustomOAuth2AuthorizationRequestResolver.java
@@ -1,0 +1,63 @@
+package haennihaesseo.sandoll.global.auth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Base64;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+@Slf4j
+public class CustomOAuth2AuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+
+  private final DefaultOAuth2AuthorizationRequestResolver defaultResolver;
+
+  public CustomOAuth2AuthorizationRequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
+    this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(
+        clientRegistrationRepository, "/oauth2/authorization");
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+    OAuth2AuthorizationRequest authorizationRequest = defaultResolver.resolve(request);
+    return customizeState(request, authorizationRequest);
+  }
+
+  @Override
+  public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+    OAuth2AuthorizationRequest authorizationRequest = defaultResolver.resolve(request, clientRegistrationId);
+    return customizeState(request, authorizationRequest);
+  }
+
+  private OAuth2AuthorizationRequest customizeState(HttpServletRequest request, OAuth2AuthorizationRequest authorizationRequest) {
+    if (authorizationRequest == null) {
+      return null;
+    }
+
+    String redirect = request.getParameter("redirect");
+    log.info("CustomOAuth2AuthorizationRequestResolver - redirect parameter: {}", redirect);
+    if (redirect == null || redirect.isBlank()) {
+      return authorizationRequest;
+    }
+
+    if (!isValidRedirectPath(redirect)) {
+      return authorizationRequest;
+    }
+
+    String originalState = authorizationRequest.getState();
+    String encodedRedirect = Base64.getUrlEncoder().withoutPadding()
+        .encodeToString(redirect.getBytes(StandardCharsets.UTF_8));
+    String customState = originalState + "_" + encodedRedirect;
+
+    return OAuth2AuthorizationRequest.from(authorizationRequest)
+        .state(customState)
+        .build();
+  }
+
+  private boolean isValidRedirectPath(String redirect) {
+    // 추후 더 강력하게 검증 로직 추가 가능 - ex. prefix 정행두기 (/app, /user 등)
+    return redirect.startsWith("/") && !redirect.startsWith("//");
+  }
+}

--- a/src/main/java/haennihaesseo/sandoll/global/config/SecurityConfig.java
+++ b/src/main/java/haennihaesseo/sandoll/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package haennihaesseo.sandoll.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import haennihaesseo.sandoll.global.auth.handler.CustomOAuth2AuthorizationRequestResolver;
 import haennihaesseo.sandoll.global.auth.handler.OAuthLoginFailureHandler;
 import haennihaesseo.sandoll.global.auth.handler.OAuthLoginSuccessHandler;
 import haennihaesseo.sandoll.global.auth.util.JwtFilter;
@@ -22,6 +23,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -37,6 +39,7 @@ public class SecurityConfig {
   private final OAuthLoginSuccessHandler oAuthLoginSuccessHandler;
   private final OAuthLoginFailureHandler oAuthLoginFailureHandler;
   private final ObjectMapper objectMapper;
+  private final ClientRegistrationRepository clientRegistrationRepository;
 
   @Value("${app.server-url}")
   private String serverUrl;
@@ -111,6 +114,10 @@ public class SecurityConfig {
             .anyRequest().authenticated()
         )
         .oauth2Login(oauth -> oauth
+            .authorizationEndpoint(authorization -> authorization
+                .authorizationRequestResolver(
+                    new CustomOAuth2AuthorizationRequestResolver(clientRegistrationRepository))
+            )
             .successHandler(oAuthLoginSuccessHandler)
             .failureHandler(oAuthLoginFailureHandler)
         )


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #66 

### 💡 작업내용
 - OAuth 로그인 후 프론트에서 원하는 페이지로 리다이렉트할 수 있도록 `redirect` 파라미터 지원 추가                                                                               
     - 기존: 로그인 후 항상 고정된 `REDIRECT_URL`로 이동                                                                                                                             
    - 변경: `/oauth2/authorization/kakao?redirect=/login` 요청 시 → `http://localhost:3000/login?tmpKey=xxx`로 이동 

- 적용 방법 : state 활용
     - OAuth 흐름은 `우리 서버 → 카카오 → 우리 서버(콜백)`으로 진행됩니다. 그 동안 프론트가 보낸 `redirect=/login`은 카카오를 거치는 동안 사라지기 때문에, 카카오가 유일하게 그대로 돌려주는 값인 `state` 파라미터에 redirect 경로를 숨겨서 전달합니다. 
     - 기존 'state' 파라미터는 “CSRF 방지”용으로 따로 resolver를 설정하지 않으면 default로 spring에서 랜덤값을 전달합니다.
     - CustomOAuth2AuthorizationRequestResolver.java 에다가 resolver를 따로 설정하여 기존 state값에 redirect 경로를 인코딩한 값을 추가하여 보냅니다.

  ### 예시 전체 흐름                                                                                                                                                                    
                                                                                                                                                                                  
  1. 프론트 → 서버: /oauth2/authorization/kakao?redirect=/login                                                                                                                   
  2. CustomOAuth2AuthorizationRequestResolver:                                                                                                                                    
    - redirect 파라미터 추출 : /login     
    - Base64 인코딩 값 : L2xvZ2lu                                                                                                                                    
    - state에 Base64 인코딩해서 추가: "원래state_L2xvZ2lu"                                                                                                                        
  3. 서버 → 카카오: 로그인 페이지 (state 포함)                                                                                                                                    
  4. 카카오 → 서버: 콜백 (state 그대로 돌아옴)                                                                                                                                    
  5. OAuthLoginSuccessHandler:                                                                                                                                                    
    - state에서 redirect 경로 디코딩: "/login"                                                                                                                                    
    - 리다이렉트: http://localhost:3000/login?tmpKey=xxx                                                                                                                          
  6. 프론트: /login 페이지에서 tmpKey로 토큰 교환   

### 📝 기타
- 보안: 상대 경로(`/`로 시작)만 허용, `//`로 시작하는 외부 URL 차단 
      - //evil.com 같은 scheme-relative URL 차단 (오픈리다이렉트 방지)
- redirect url 변경으로 .env 파일 변경합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * OAuth2 인증 후 사용자가 로그인 전에 방문하려던 페이지로 자동으로 리다이렉션되는 기능을 추가했습니다.
  * 리다이렉트 경로의 유효성 검증 메커니즘을 강화하여 보안성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->