### PR TITLE
[Fix/#77] : 긴 오디오 STT 처리를 위한 GCS URI 방식 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
 	// Google Cloud Speech-to-Text
 	implementation 'com.google.cloud:google-cloud-speech:4.52.0'
 
+	// Google Cloud Storage (for STT with GCS URI)
+	implementation 'com.google.cloud:google-cloud-storage:2.30.1'
+
 	implementation 'org.apache.commons:commons-text:1.11.0'
 
 	// Rate Limiting (Bucket4j + Redis)

--- a/src/main/java/haennihaesseo/sandoll/global/infra/stt/GcsClient.java
+++ b/src/main/java/haennihaesseo/sandoll/global/infra/stt/GcsClient.java
@@ -1,0 +1,70 @@
+package haennihaesseo.sandoll.global.infra.stt;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import haennihaesseo.sandoll.global.exception.GlobalException;
+import haennihaesseo.sandoll.global.status.ErrorStatus;
+import haennihaesseo.sandoll.global.util.ResourceLoader;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class GcsClient {
+
+    private final Storage storage;
+
+    @Value("${gcs.bucket-name}")
+    private String bucketName;
+
+    public GcsClient() {
+        try {
+            GoogleCredentials credentials = GoogleCredentials.fromStream(
+                    ResourceLoader.getResourceAsStream("google-stt-key.json"));
+            this.storage = StorageOptions.newBuilder()
+                    .setCredentials(credentials)
+                    .build()
+                    .getService();
+        } catch (IOException e) {
+            throw new GlobalException(ErrorStatus.STT_SERVICE_ERROR);
+        }
+    }
+
+    public String uploadAudio(byte[] audioBytes, String contentType) {
+        String fileName = "stt-audio/" + UUID.randomUUID() + ".webm";
+
+        BlobId blobId = BlobId.of(bucketName, fileName);
+        BlobInfo blobInfo = BlobInfo.newBuilder(blobId)
+                .setContentType(contentType)
+                .build();
+
+        storage.create(blobInfo, audioBytes);
+
+        String gcsUri = String.format("gs://%s/%s", bucketName, fileName);
+        log.info("[GCS] 오디오 업로드 완료: {}", gcsUri);
+
+        return gcsUri;
+    }
+
+    public void deleteAudio(String gcsUri) {
+        try {
+            String prefix = String.format("gs://%s/", bucketName);
+            if (!gcsUri.startsWith(prefix)) {
+                return;
+            }
+            String fileName = gcsUri.substring(prefix.length());
+            BlobId blobId = BlobId.of(bucketName, fileName);
+            storage.delete(blobId);
+            log.info("[GCS] 오디오 삭제 완료: {}", gcsUri);
+        } catch (Exception e) {
+            log.warn("[GCS] 오디오 삭제 실패: {}", gcsUri, e);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -65,6 +65,9 @@ app.letter-encrypt-key=${LETTER_ENCRYPT_KEY}
 #Python server
 external.python-server-url=${PYTHON_SERVER_URL}
 
+# GCS (Google Cloud Storage for STT)
+gcs.bucket-name=${GCS_BUCKET_NAME}
+
 # Rate Limiting
 rate-limit.enabled=false
 rate-limit.requests-per-hour=10


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #77 

### 💡 작업내용
긴 오디오 처리시 뜨는 에러 문구를 확인해보니 io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Inline audio exceeds duration limit. Please use a GCS URI. 라고 GCS URI를 사용하라고 권고하고 있습니다. 그래서 구글 클라우드 콘솔에서 관련 Storage Bucket을 생성하여 STT 처리 전 잠깐 올리고 완료하면 삭제하는 코드 추가하였습니다.
  - GcsClient 추가: GCS 오디오 업로드/삭제 기능                                                                                                                                   
  - 20초 미만: inline content로 동기 처리 (빠름)                                                                                                                                  
  - 20초 이상: GCS URI로 비동기 처리 (안정적)                                                                                                                                     
  - 처리 완료 후 GCS 파일 자동 삭제 

또한 20초를 기준으로 선택한 이유는 아직 이유는 발견하지 못했으나 20초 미만으로 동기 요청 시에는 잘 되는데, 20초 이상으로 하면 동기 요청이 계속 실패하는 것을 여러 테스트를 통해 발견하였습니다. Google Document에는 60초로 되어있는데 실제로는 20초로 되어서 이 부분은 혼라스럽긴한데, 우선 20초를 기준으로 나누었습니다. 추후 관련 자료 구글링해서 왜 그런지 확인해볼 예정입니다.

### 📸 스크린샷(선택)

### 📝 기타
.env 파일 수정되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 음성 인식 시 장시간 오디오 파일 처리를 위한 클라우드 스토리지 통합 추가
  * 단시간 오디오는 기존 방식으로, 장시간 오디오는 클라우드 저장소를 통해 처리하도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->