### PR TITLE
[Fix/#87] : 폰트 조회 방식 voice, context 분리

### DIFF
--- a/src/main/java/haennihaesseo/sandoll/domain/font/controller/FontController.java
+++ b/src/main/java/haennihaesseo/sandoll/domain/font/controller/FontController.java
@@ -3,6 +3,7 @@ package haennihaesseo.sandoll.domain.font.controller;
 import haennihaesseo.sandoll.domain.font.dto.request.FontSettingRequest;
 import haennihaesseo.sandoll.domain.font.dto.response.RecommendFontResponse;
 import haennihaesseo.sandoll.domain.font.dto.response.RefreshFontResponse;
+import haennihaesseo.sandoll.domain.font.entity.enums.FontType;
 import haennihaesseo.sandoll.domain.font.service.FontService;
 import haennihaesseo.sandoll.domain.font.status.FontSuccessStatus;
 import haennihaesseo.sandoll.global.response.ApiResponse;
@@ -12,12 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Font Setting", description = "폰트 설정 및 추천 API")
 @RestController
@@ -45,9 +41,10 @@ public class FontController {
   )
   @GetMapping("/font")
   public ResponseEntity<ApiResponse<RecommendFontResponse>> getRecommendFont(
-      @RequestHeader("letterId") String letterId
+      @RequestHeader("letterId") String letterId,
+      @RequestParam(name = "type", defaultValue = "VOICE") FontType fontType
   ) {
-    RecommendFontResponse response = fontService.getRecommendFonts(letterId);
+    RecommendFontResponse response = fontService.getRecommendFonts(letterId, fontType);
     return ApiResponse.success(FontSuccessStatus.SUCCESS_306, response);
   }
 

--- a/src/main/java/haennihaesseo/sandoll/domain/font/converter/FontConverter.java
+++ b/src/main/java/haennihaesseo/sandoll/domain/font/converter/FontConverter.java
@@ -36,10 +36,9 @@ public class FontConverter {
         .toList();
   }
 
-  public RecommendFontResponse toRecommendFontResponse(List<RecommendFont> voiceFont, List<RecommendFont> contextFont) {
+  public RecommendFontResponse toRecommendFontResponse(List<RecommendFont> fonts) {
     return RecommendFontResponse.builder()
-        .voiceFonts(voiceFont)
-        .contextFonts(contextFont)
+        .fonts(fonts)
         .build();
   }
 }

--- a/src/main/java/haennihaesseo/sandoll/domain/font/dto/response/RecommendFontResponse.java
+++ b/src/main/java/haennihaesseo/sandoll/domain/font/dto/response/RecommendFontResponse.java
@@ -10,6 +10,5 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class RecommendFontResponse {
-  List<RecommendFont> voiceFonts;
-  List<RecommendFont> contextFonts;
+  List<RecommendFont> fonts;
 }


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #87 

### 💡 작업내용

- 문맥 폰트 추천에 시간이 걸리기 때문에 voice와 context를 분리해서 조회하도록 수정합니다.
- Request Parameter의 값에 따라 해당하는 폰트 리스트를 반환합니다.

### 📸 스크린샷(선택)

### 📝 기타

[3.6] api 명세 수정하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 폰트 추천 API에 유형 필터링이 추가되었습니다. 음성(VOICE) 또는 맥락(CONTEXT) 폰트를 선택할 수 있는 새로운 쿼리 파라미터가 제공됩니다.

* **개선 사항**
  * 폰트 추천 응답 구조가 개선되었습니다. 이제 단일 폰트 목록으로 통합되어 반환됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->